### PR TITLE
Enhance GTFS screener UI and metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,107 +6,206 @@
 <title>GTFS — Least Worst Frequency (Kanban v2)</title>
 <style>
   :root{
-    --bg:#0b1220; --panel:#111827; --muted:#9ca3af; --text:#e5e7eb; --line:#1f2937;
-    --chip:#1f2937; --chipText:#cbd5e1; --accent:#60a5fa; --btn:#2563eb; --btnText:#fff;
-    --good:#10b981; --ok:#22c55e; --mid:#06b6d4; --warn:#f59e0b; --meh:#ef4444; --dark:#374151;
+    --bg:#0b1220;
+    --bgGradient:radial-gradient(1200px 600px at 10% 0%, #0e172a 0%, #0b1220 50%, #090f1b 100%);
+    --panel:#111827;
+    --muted:#9ca3af;
+    --text:#e5e7eb;
+    --line:#1f2937;
+    --chip:#1f2937;
+    --chipText:#cbd5e1;
+    --accent:#60a5fa;
+    --btn:#2563eb;
+    --btnText:#fff;
+    --card:#0f172a;
+    --inputBg:#0b1220;
+    --tableStripe:rgba(255,255,255,.02);
+    --bannerBg:rgba(37,99,235,.12);
+    --highlight:rgba(96,165,250,.25);
+    --modalOverlay:rgba(0,0,0,.6);
+    --good:#10b981;
+    --ok:#22c55e;
+    --mid:#06b6d4;
+    --warn:#f59e0b;
+    --meh:#ef4444;
+    --dark:#374151;
+  }
+  body[data-theme="light"]{
+    --bg:#f5f7fb;
+    --bgGradient:radial-gradient(1200px 600px at 10% 0%, #ffffff 0%, #eef2ff 50%, #e2e8f0 100%);
+    --panel:#ffffff;
+    --muted:#4b5563;
+    --text:#1f2937;
+    --line:#d1d5db;
+    --chip:#e5e7eb;
+    --chipText:#1f2937;
+    --accent:#2563eb;
+    --btn:#2563eb;
+    --btnText:#fff;
+    --card:#f1f5f9;
+    --inputBg:#f8fafc;
+    --tableStripe:rgba(15,23,42,.04);
+    --bannerBg:rgba(37,99,235,.16);
+    --highlight:rgba(59,130,246,.2);
+    --modalOverlay:rgba(15,23,42,.35);
   }
   *{box-sizing:border-box}
   body{
-    font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial;
-    background: radial-gradient(1200px 600px at 10% 0%, #0e172a 0%, #0b1220 50%, #090f1b 100%);
-    color: var(--text); margin:0; padding:24px;
+    font-family:ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial;
+    background:var(--bgGradient);
+    color:var(--text);
+    margin:0;
+    padding:24px;
+    min-height:100vh;
+    transition:background .3s ease,color .3s ease;
   }
   .wrap{max-width:1200px;margin:0 auto}
-  header{display:flex;gap:12px;align-items:center;justify-content:space-between;margin-bottom:16px}
+  header{display:flex;gap:16px;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap}
   h1{font-size:22px;margin:0;font-weight:800;letter-spacing:.2px}
-  .panel{background:var(--panel); border:1px solid var(--line); border-radius:16px; box-shadow: 0 6px 20px rgba(0,0,0,.35); padding:16px; margin-bottom:16px}
-  .grid{display:grid; grid-template-columns:2fr 1fr 1fr 1fr; gap:12px}
-  label{font-weight:700; font-size:12px; color:var(--muted); text-transform:uppercase; letter-spacing:.04em}
-  input[type="file"], input[type="time"]{
-    width:100%; padding:10px 12px; border-radius:10px; background:#0b1220; border:1px solid var(--line); color:var(--text)
+  .headerActions{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+  .themeToggle{display:flex;align-items:center;gap:8px;background:var(--card);border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--muted)}
+  .themeToggle span{font-weight:700;text-transform:uppercase;letter-spacing:.05em}
+  .themeButtons{display:flex;border-radius:12px;overflow:hidden}
+  .themeButtons button{background:transparent;border:0;color:var(--muted);padding:6px 10px;font-weight:700;cursor:pointer;transition:background .2s ease,color .2s ease}
+  .themeButtons button.active{background:var(--btn);color:var(--btnText)}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.25);padding:16px;margin-bottom:16px}
+  .controls{margin-bottom:20px}
+  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;align-items:end}
+  .field{display:flex;flex-direction:column;gap:6px}
+  .field.action{justify-content:flex-end}
+  label{font-weight:700;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
+  input[type="file"],input[type="time"]{
+    width:100%;padding:10px 12px;border-radius:10px;background:var(--inputBg);border:1px solid var(--line);color:var(--text)
   }
-  .toolbar{display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:12px}
-  .btn{background:var(--btn); color:var(--btnText); border:0; border-radius:10px; padding:10px 14px; font-weight:800; cursor:pointer}
-  .btn:disabled{opacity:.5; cursor:not-allowed}
-  .chip{background:var(--chip); color:var(--chipText); padding:8px 10px; border-radius:999px; font-size:12px; border:1px solid var(--line)}
-  .seg{display:flex; gap:6px; background:#0b1220; border:1px solid var(--line); padding:4px; border-radius:12px}
-  .seg button{background:transparent; color:var(--muted); border:0; padding:8px 10px; border-radius:8px; cursor:pointer; font-weight:700}
-  .seg button.active{background:var(--btn); color:#fff}
-  .switch{display:flex; gap:8px; align-items:center}
+  input[type="file"]::-webkit-file-upload-button{display:none}
+  input[type="file"]::file-selector-button{display:none}
+  .toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:16px}
+  .btn{background:var(--btn);color:var(--btnText);border:0;border-radius:10px;padding:10px 16px;font-weight:800;cursor:pointer;transition:opacity .2s ease,transform .2s ease}
+  .btn:disabled{opacity:.5;cursor:not-allowed}
+  .btn:not(:disabled):active{transform:translateY(1px)}
+  .chip{background:var(--chip);color:var(--chipText);padding:8px 10px;border-radius:999px;font-size:12px;border:1px solid var(--line)}
+  .seg{display:flex;gap:6px;background:var(--card);border:1px solid var(--line);padding:4px;border-radius:12px}
+  .seg button{background:transparent;color:var(--muted);border:0;padding:8px 10px;border-radius:8px;cursor:pointer;font-weight:700}
+  .seg button.active{background:var(--btn);color:#fff}
+  .switch{display:flex;gap:8px;align-items:center;color:var(--muted);font-weight:700}
   .switch input{accent-color:var(--accent)}
-  .search{flex:1; display:flex; align-items:center; gap:8px; background:#0b1220; border:1px solid var(--line); padding:8px 10px; border-radius:10px}
-  .search input{flex:1; background:transparent; border:0; color:var(--text); outline:none}
-  .right{margin-left:auto}
+  .search{flex:1;display:flex;align-items:center;gap:8px;background:var(--card);border:1px solid var(--line);padding:8px 10px;border-radius:10px}
+  .search input{flex:1;background:transparent;border:0;color:var(--text);outline:none}
+  .banner{display:none}
+  .bannerHeader{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:12px}
+  .bannerHeader h2{margin:0;font-size:16px;font-weight:800}
+  .bannerHeader .hint{color:var(--muted);font-size:12px}
+  .bannerBody{background:var(--bannerBg);border-radius:12px;padding:12px;display:flex;flex-wrap:wrap;gap:12px;align-items:center}
+  .bannerEmpty{color:var(--muted);font-size:13px}
+  .bannerPills{display:flex;flex-wrap:wrap;gap:8px}
+  .bannerPills button{background:var(--btn);color:var(--btnText);border:0;border-radius:999px;padding:6px 12px;font-weight:700;font-size:13px;cursor:pointer;transition:opacity .2s ease}
+  .bannerPills button:hover{opacity:.85}
   /* Kanban */
-  .kanban{display:grid; grid-template-columns:repeat(6,1fr); gap:12px}
-  .col{background:#0b1220; border:1px solid var(--line); border-radius:14px; padding:12px; min-height:120px}
-  .col h3{margin:0 0 8px; font-size:13px; color:#cbd5e1; letter-spacing:.03em; text-transform:uppercase}
-  .col .hint{color:var(--muted); font-size:12px; margin-bottom:8px}
-  .cards{display:flex; flex-direction:column; gap:8px; max-height:280px; overflow:auto}
-  .card{background:#0f172a; border:1px solid #1f2937; border-radius:10px; padding:8px 10px; cursor:pointer}
-  .card:hover{border-color:#334155}
-  .routeLine{display:flex; align-items:center; gap:6px; font-weight:800}
-  .day{font-size:11px; color:#94a3b8}
-  .dir{font-size:11px; background:#0b1220; border:1px solid var(--line); color:#cbd5e1; padding:2px 6px; border-radius:999px}
-  .stat{font-size:11px; color:#a5b4fc}
+  .kanban{display:grid;grid-template-columns:repeat(6,1fr);gap:12px}
+  .col{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:12px;min-height:120px}
+  .col h3{margin:0 0 8px;font-size:13px;color:var(--muted);letter-spacing:.03em;text-transform:uppercase}
+  .col .hint{color:var(--muted);font-size:12px;margin-bottom:8px}
+  .cards{display:flex;flex-direction:column;gap:8px;max-height:280px;overflow:auto}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:8px 10px;cursor:pointer;transition:border-color .2s ease,transform .2s ease}
+  .card:hover{border-color:var(--accent);transform:translateY(-1px)}
+  .routeLine{display:flex;align-items:center;gap:6px;font-weight:800}
+  .day{font-size:11px;color:var(--muted)}
+  .dir{font-size:11px;background:var(--inputBg);border:1px solid var(--line);color:var(--chipText);padding:2px 6px;border-radius:999px}
+  .stat{font-size:11px;color:var(--accent)}
   /* Table */
-  table{width:100%; border-collapse:separate; border-spacing:0; font-size:14px}
-  thead th{position:sticky; top:0; backdrop-filter: blur(6px); z-index:3; background:rgba(17,24,39,.9);}
-  th,td{border-bottom:1px solid var(--line); padding:10px 12px; text-align:center}
-  tbody tr:nth-child(odd){background:rgba(255,255,255,.02)}
-  td.route, th.route{text-align:left; position:sticky; left:0; background:rgba(17,24,39,.95); z-index:2}
-  .tier{font-weight:900; padding:6px 10px; border-radius:999px; display:inline-block; min-width:64px}
-  .t10{background:rgba(16,185,129,.15); color:var(--good); border:1px solid rgba(16,185,129,.35)}
-  .t15{background:rgba(34,197,94,.15); color:var(--ok); border:1px solid rgba(34,197,94,.35)}
-  .t20{background:rgba(6,182,212,.15); color:var(--mid); border:1px solid rgba(6,182,212,.35)}
-  .t30{background:rgba(245,158,11,.15); color:var(--warn); border:1px solid rgba(245,158,11,.35)}
-  .t60{background:rgba(239,68,68,.15); color:var(--meh); border:1px solid rgba(239,68,68,.35)}
-  .tBig{background:rgba(107,114,128,.15); color:#cbd5e1; border:1px solid rgba(107,114,128,.4)}
-  .badge{background:#0b1220; border:1px solid var(--line); color:#cbd5e1; padding:4px 8px; border-radius:8px; font-size:12px}
+  table{width:100%;border-collapse:separate;border-spacing:0;font-size:14px}
+  thead th{position:sticky;top:0;backdrop-filter:blur(6px);z-index:3;background:var(--panel)}
+  th,td{border-bottom:1px solid var(--line);padding:10px 12px;text-align:center}
+  tbody tr:nth-child(odd){background:var(--tableStripe)}
+  tbody tr.highlight{animation:highlight 1.4s ease}
+  @keyframes highlight{0%{background:var(--highlight);}100%{background:transparent;}}
+  td.route,th.route{text-align:left;position:sticky;left:0;background:var(--panel);z-index:2}
+  tbody tr:nth-child(odd) td.route{background:var(--tableStripe)}
+  .tier{font-weight:900;padding:6px 10px;border-radius:999px;display:inline-block;min-width:64px;cursor:help}
+  .t10{background:rgba(16,185,129,.15);color:var(--good);border:1px solid rgba(16,185,129,.35)}
+  .t15{background:rgba(34,197,94,.15);color:var(--ok);border:1px solid rgba(34,197,94,.35)}
+  .t20{background:rgba(6,182,212,.15);color:var(--mid);border:1px solid rgba(6,182,212,.35)}
+  .t30{background:rgba(245,158,11,.15);color:var(--warn);border:1px solid rgba(245,158,11,.35)}
+  .t60{background:rgba(239,68,68,.15);color:var(--meh);border:1px solid rgba(239,68,68,.35)}
+  .tBig{background:rgba(107,114,128,.15);color:var(--muted);border:1px solid rgba(107,114,128,.4)}
+  .badge{background:var(--card);border:1px solid var(--line);color:var(--chipText);padding:6px 10px;border-radius:8px;font-size:12px;font-weight:700}
   /* Modal */
-  .modal{position:fixed; inset:0; display:none; align-items:center; justify-content:center; background:rgba(0,0,0,.6); z-index:100}
-  .dialog{background:#0b1220; border:1px solid var(--line); border-radius:16px; width:min(720px,92vw); padding:16px}
-  .dialog h3{margin:0 0 8px}
-  .dialog pre{background:#0f172a; border:1px solid #1f2937; padding:12px; border-radius:8px; max-height:300px; overflow:auto; color:#cbd5e1; font-size:12px}
-  .close{float:right; background:#1f2937; border:1px solid #334155; color:#cbd5e1; border-radius:8px; padding:6px 10px; cursor:pointer}
+  .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:var(--modalOverlay);z-index:100}
+  .dialog{background:var(--panel);border:1px solid var(--line);border-radius:16px;width:min(720px,92vw);padding:20px;max-height:90vh;overflow:auto}
+  .dialog h3{margin:0 0 12px}
+  .close{float:right;background:var(--chip);border:1px solid var(--line);color:var(--chipText);border-radius:8px;padding:6px 10px;cursor:pointer}
+  .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin-bottom:16px}
+  .metricCard{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px}
+  .metricLabel{display:block;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;font-weight:700;margin-bottom:4px}
+  .metricValue{font-size:20px;font-weight:800}
+  .metricSub{font-size:12px;color:var(--muted);margin-top:6px}
+  .gapList{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px}
+  .gapList .chip{background:var(--card)}
+  .departures{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}
+  .departures h4{margin:0 0 6px;font-size:13px;font-weight:700}
+  .departures p{margin:0;font-size:13px;color:var(--muted);line-height:1.4}
+  .modalBuckets{width:100%;border-collapse:separate;border-spacing:0;margin-bottom:0}
+  .modalBuckets th,.modalBuckets td{text-align:left;padding:6px 8px;border-bottom:1px solid var(--line);font-size:13px}
+  .modalBuckets th{color:var(--muted);text-transform:uppercase;letter-spacing:.04em;font-size:11px}
+  .muted{color:var(--muted)}
+  tbody tr{scroll-margin-top:80px}
+  @media(max-width:900px){
+    .kanban{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  }
+  @media(max-width:600px){
+    body{padding:16px}
+    header{margin-bottom:16px}
+    .toolbar{flex-direction:column;align-items:stretch}
+    .search{width:100%}
+    .themeToggle{width:100%;justify-content:space-between}
+  }
 </style>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
 </head>
-<body>
+<body data-theme="dark">
   <div class="wrap">
     <header>
       <h1>GTFS — Least Worst Frequency</h1>
-      <span class="badge">Strict +2 min grace · max 2 events</span>
+      <div class="headerActions">
+        <div class="themeToggle" role="group" aria-label="Theme">
+          <span>Theme</span>
+          <div class="themeButtons">
+            <button type="button" data-theme-choice="dark" class="active">Dark</button>
+            <button type="button" data-theme-choice="light">Light</button>
+          </div>
+        </div>
+        <span class="badge">Strict +2 min grace · max 2 events</span>
+      </div>
     </header>
 
-    <section class="panel">
+    <section class="panel controls">
       <div class="grid">
-        <div>
-          <label>GTFS ZIP</label>
+        <div class="field">
+          <label for="gtfs">GTFS ZIP</label>
           <input id="gtfs" type="file" accept=".zip">
         </div>
-        <div>
-          <label>Start</label>
+        <div class="field">
+          <label for="t0">Start</label>
           <input id="t0" type="time" value="07:00">
         </div>
-        <div>
-          <label>End</label>
+        <div class="field">
+          <label for="t1">End</label>
           <input id="t1" type="time" value="22:00">
         </div>
-        <div>
+        <div class="field action">
           <label>&nbsp;</label>
           <button id="go" class="btn" disabled>Analyze</button>
         </div>
       </div>
       <div class="toolbar">
         <div class="seg" role="tablist" aria-label="Day filter">
-          <button data-day="Weekday" class="active">Weekday</button>
-          <button data-day="Saturday">Saturday</button>
-          <button data-day="Sunday">Sunday</button>
-          <button data-day="All">All</button>
+          <button type="button" data-day="Weekday" class="active">Weekday</button>
+          <button type="button" data-day="Saturday">Saturday</button>
+          <button type="button" data-day="Sunday">Sunday</button>
+          <button type="button" data-day="All">All</button>
         </div>
-        <button id="focus15" class="btn">Weekday: 15-min or better</button>
+        <button id="focus15" class="btn" type="button">Weekday: 15-min or better</button>
         <div class="switch">
           <input id="merge" type="checkbox">
           <label for="merge">Merge directions per route</label>
@@ -116,6 +214,17 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path stroke="#9ca3af" stroke-width="2" d="m21 21-4.35-4.35M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z"/></svg>
           <input id="q" placeholder="Search routes…">
         </div>
+      </div>
+    </section>
+
+    <section id="frequentBanner" class="panel banner">
+      <div class="bannerHeader">
+        <h2 id="bannerTitle">Weekday ≤15 min (07:00–22:00)</h2>
+        <span class="hint">Strict +2 min grace · max 2 events</span>
+      </div>
+      <div class="bannerBody">
+        <div id="bannerEmpty" class="bannerEmpty">No ≤15 min routes found.</div>
+        <div id="bannerPills" class="bannerPills"></div>
       </div>
     </section>
 
@@ -166,6 +275,18 @@ const fileEl = document.getElementById('gtfs');
 const btn = document.getElementById('go');
 fileEl.addEventListener('change', e => btn.disabled = !e.target.files[0]);
 btn.addEventListener('click', analyze);
+
+const themeButtons = document.querySelectorAll('[data-theme-choice]');
+themeButtons.forEach(btnEl => btnEl.addEventListener('click', () => applyTheme(btnEl.dataset.themeChoice)));
+const savedTheme = localStorage.getItem('gtfs-theme');
+applyTheme(savedTheme || 'dark');
+
+function applyTheme(theme){
+  const t = theme === 'light' ? 'light' : 'dark';
+  document.body.setAttribute('data-theme', t);
+  localStorage.setItem('gtfs-theme', t);
+  themeButtons.forEach(b => b.classList.toggle('active', b.dataset.themeChoice === t));
+}
 
 document.querySelectorAll('.seg button').forEach(b=>b.addEventListener('click',()=>{
   document.querySelectorAll('.seg button').forEach(x=>x.classList.remove('active'));
@@ -246,7 +367,6 @@ async function analyze(){
   const routeById={}; for(const r of routes){ if(r.route_id) routeById[r.route_id]=r; }
   const calByService={}; for(const c of calendar){ if(c.service_id) calByService[c.service_id]=c; }
 
-  // origin departure per trip
   const originForTrip=new Map();
   {
     const earliest=new Map();
@@ -282,7 +402,7 @@ async function analyze(){
     const dayTrips=tripsForDay(day);
     const map=new Map();
     for(const tr of dayTrips){
-      const dir=(tr.direction_id!==undefined && tr.direction_id!=='' && tr.direction_id!==null)? tr.direction_id : '0';
+      const dir=(tr.direction_id!==undefined && tr.direction_id!=='' && tr.direction_id!==null)? String(tr.direction_id) : '0';
       const key=`${tr.route_id}::${dir}`;
       if(!map.has(key)) map.set(key,[]);
       map.get(key).push(tr.trip_id);
@@ -297,7 +417,7 @@ async function analyze(){
       for(const tid of tripIds){
         const m=originForTrip.get(tid);
         if(m==null) continue;
-        if(m<t0 || m>t1) continue; // inclusive
+        if(m<t0 || m>t1) continue; // inclusive window
         times.push(m);
       }
       if(times.length<2) continue;
@@ -324,6 +444,31 @@ async function analyze(){
   document.getElementById('tableWrap').style.display='block';
 }
 
+function cloneRow(row){
+  return {route:row.route, dir:String(row.dir), day:row.day, b:{...row.b}, avg:row.avg, tier:row.tier, hw:[...row.hw], times:[...row.times]};
+}
+
+function mergeRows(rows){
+  const m=new Map();
+  for(const r of rows){
+    const key=`${r.route}::${r.day}`;
+    if(!m.has(key)) m.set(key,{route:r.route, day:r.day, hw:[], times:[]});
+    const obj=m.get(key);
+    obj.hw.push(...r.hw);
+    obj.times.push(...r.times);
+  }
+  const merged=[];
+  for(const [,obj] of m.entries()){
+    obj.hw.sort((a,b)=>a-b);
+    obj.times.sort((a,b)=>a-b);
+    const b=bucketCounts(obj.hw);
+    const avg=obj.hw.length ? Math.round(obj.hw.reduce((a,b)=>a+b,0)/obj.hw.length) : 0;
+    const tier=leastWorstTier(obj.hw);
+    merged.push({route:obj.route, dir:'–', day:obj.day, b, avg, tier, hw:obj.hw, times:obj.times});
+  }
+  return merged;
+}
+
 function render(opts={}){
   const activeDay = document.querySelector('.seg button.active')?.dataset.day || 'Weekday';
   const merge = document.getElementById('merge').checked;
@@ -334,42 +479,25 @@ function render(opts={}){
   if(q) rows = rows.filter(r => (''+r.route).toLowerCase().includes(q));
   if(focus15) rows = rows.filter(r => r.day==='Weekday' && (r.tier==='10'||r.tier==='15'));
 
-  // MERGE (route+day) with real headways
-  if(merge){
-    const m = new Map();
-    for(const r of rows){
-      const key = `${r.route}::${r.day}`;
-      if(!m.has(key)) m.set(key,{route:r.route, day:r.day, dir:'—', hw:[], times:[]});
-      const obj=m.get(key);
-      obj.hw = obj.hw.concat(r.hw);
-      obj.times = obj.times.concat(r.times);
-    }
-    rows = [];
-    for(const [,v] of m.entries()){
-      // Recompute counts/tier/avg from actual headways
-      v.hw.sort((a,b)=>a-b);
-      const b = bucketCounts(v.hw);
-      const avg = v.hw.length ? Math.round(v.hw.reduce((a,b)=>a+b,0)/v.hw.length) : 0;
-      const tier = leastWorstTier(v.hw);
-      rows.push({route:v.route, dir:'—', day:v.day, b, avg, tier, hw:v.hw, times:v.times.sort((a,b)=>a-b)});
-    }
+  let displayRows = merge ? mergeRows(rows) : rows.map(cloneRow);
+  if(merge && focus15){
+    displayRows = displayRows.filter(r => r.tier==='10'||r.tier==='15');
   }
 
-  // Sort for display
-  rows.sort((a,b)=>{
+  displayRows.sort((a,b)=>{
     if(a.route!==b.route) return (''+a.route).localeCompare(''+b.route,undefined,{numeric:true});
     const order={'Weekday':0,'Saturday':1,'Sunday':2};
     if(a.day!==b.day) return (order[a.day]??9)-(order[b.day]??9);
     return (''+a.dir).localeCompare(''+b.dir);
   });
 
-  // Populate KANBAN (now respects merge)
   document.querySelectorAll('.col .cards').forEach(c=>c.innerHTML='');
   const buckets = {'10':[], '15':[], '20':[], '30':[], '60':[], '>60':[]};
-  for(const r of rows) buckets[r.tier]?.push(r);
+  for(const r of displayRows) buckets[r.tier]?.push(r);
   for(const key of Object.keys(buckets)){
     const container = document.querySelector(`.col[data-tier="${key}"] .cards`);
-    const items = buckets[key];
+    if(!container) continue;
+    const items = buckets[key] || [];
     items.sort((a,b)=>(''+a.route).localeCompare(''+b.route,undefined,{numeric:true}));
     for(const it of items){
       const div = document.createElement('div');
@@ -378,7 +506,7 @@ function render(opts={}){
       div.innerHTML = `
         <div class="routeLine">
           <span>${it.route}</span>
-          <span class="dir">${it.dir}</span>
+          <span class="dir">${directionLabel(it.dir)}</span>
         </div>
         <div class="day">${it.day}</div>
         <div class="stat">avg ${it.avg} • ≤10:${it.b['≤10']} • 11–15:${it.b['11–15']}</div>
@@ -390,14 +518,20 @@ function render(opts={}){
     }
   }
 
-  // Details table
   const tbody=document.querySelector('#tbl tbody');
   tbody.innerHTML='';
-  for(const r of rows){
+  for(const r of displayRows){
     const tr=document.createElement('tr');
+    tr.dataset.route=r.route;
+    tr.dataset.day=r.day;
+    tr.dataset.dir=r.dir;
+    const tierText = r.tier==='>60' ? '&gt;60' : `${r.tier}`;
+    const tooltip = r.tier==='>60'
+      ? 'Strict rule: more than 60 min headways (over limit).'
+      : `Strict rule: maintain ≤${r.tier} min headways with up to two trips at +2 min.`;
     tr.innerHTML = `
       <td class="route">${r.route}</td>
-      <td>${r.dir}</td>
+      <td>${directionLabel(r.dir)}</td>
       <td>${r.day}</td>
       <td>${r.b['≤10']}</td>
       <td>${r.b['11–15']}</td>
@@ -406,24 +540,200 @@ function render(opts={}){
       <td>${r.b['31–60']}</td>
       <td>${r.b['>60']}</td>
       <td>${r.avg}</td>
-      <td><span class="tier ${tierClass(r.tier)}">${r.tier==='>60' ? '&gt;60' : r.tier} min</span></td>
+      <td><span class="tier ${tierClass(r.tier)}" title="${tooltip}">${tierText} min</span></td>
     `;
     tbody.appendChild(tr);
   }
+
+  updateFrequentBanner();
 }
 
-// Modal helpers
+function directionLabel(dir){
+  const val = dir==null ? '' : String(dir);
+  if(val==='–' || val==='—') return '–';
+  if(val==='0') return 'Outbound';
+  if(val==='1') return 'Inbound';
+  return val;
+}
+
+function updateFrequentBanner(){
+  const banner=document.getElementById('frequentBanner');
+  const pills=document.getElementById('bannerPills');
+  const empty=document.getElementById('bannerEmpty');
+  if(!RAW_ROWS.length){
+    banner.style.display='none';
+    return;
+  }
+  const start=document.getElementById('t0').value||'07:00';
+  const end=document.getElementById('t1').value||'22:00';
+  document.getElementById('bannerTitle').textContent=`Weekday ≤15 min (${start}–${end})`;
+
+  const weekdayRows = RAW_ROWS.filter(r=>r.day==='Weekday');
+  const merged = mergeRows(weekdayRows);
+  const frequent = merged.filter(r=>r.tier==='10' || r.tier==='15');
+
+  pills.innerHTML='';
+  if(!frequent.length){
+    empty.style.display='block';
+  }else{
+    empty.style.display='none';
+    frequent.sort((a,b)=>(''+a.route).localeCompare(''+b.route,undefined,{numeric:true}));
+    for(const r of frequent){
+      const pill=document.createElement('button');
+      pill.type='button';
+      pill.textContent=r.route;
+      pill.addEventListener('click',()=>scrollToRoute(r.route));
+      pills.appendChild(pill);
+    }
+  }
+  banner.style.display='block';
+}
+
+function scrollToRoute(route){
+  const weekdayButton=document.querySelector('.seg button[data-day="Weekday"]');
+  if(weekdayButton && !weekdayButton.classList.contains('active')){
+    document.querySelectorAll('.seg button').forEach(x=>x.classList.remove('active'));
+    weekdayButton.classList.add('active');
+  }
+  const searchInput=document.getElementById('q');
+  if(searchInput.value){
+    searchInput.value='';
+  }
+  render();
+  requestAnimationFrame(()=>{
+    const rows=[...document.querySelectorAll('#tbl tbody tr')].filter(tr=>tr.dataset.route===route && tr.dataset.day==='Weekday');
+    if(rows.length){
+      const target=rows[0];
+      target.classList.remove('highlight');
+      void target.offsetWidth;
+      target.classList.add('highlight');
+      target.scrollIntoView({behavior:'smooth',block:'center'});
+    }
+  });
+}
+
+function computeMedian(hw){
+  if(!hw.length) return 0;
+  const sorted=[...hw].sort((a,b)=>a-b);
+  const mid=Math.floor(sorted.length/2);
+  if(sorted.length%2===1) return sorted[mid];
+  return (sorted[mid-1]+sorted[mid])/2;
+}
+function computeMode(hw){
+  if(!hw.length) return 0;
+  const counts=new Map();
+  for(const h of hw){
+    counts.set(h,(counts.get(h)||0)+1);
+  }
+  let best=hw[0]; let bestCount=0;
+  for(const [value,count] of counts.entries()){
+    if(count>bestCount || (count===bestCount && value<best)){
+      best=value; bestCount=count;
+    }
+  }
+  return best;
+}
+function formatMinutes(val){
+  if(Number.isInteger(val)) return `${val} min`;
+  return `${Math.round(val*10)/10} min`;
+}
+function formatGroupedGaps(hw){
+  const sorted=[...hw].sort((a,b)=>b-a).slice(0,10);
+  const counts=new Map();
+  for(const h of sorted){
+    counts.set(h,(counts.get(h)||0)+1);
+  }
+  return [...counts.entries()].sort((a,b)=>b[0]-a[0]).map(([gap,count])=>`${gap} min (×${count})`);
+}
+function uniqueTimes(times){
+  const seen=new Set();
+  const list=[];
+  for(const t of times){
+    if(!seen.has(t)){
+      seen.add(t);
+      list.push(t);
+    }
+  }
+  return list;
+}
+function timesByDirection(route, day){
+  const result={'0':[], '1':[]};
+  for(const row of RAW_ROWS){
+    if(row.route===route && row.day===day){
+      const dir=String(row.dir);
+      if(!result[dir]) result[dir]=[];
+      result[dir]=result[dir].concat(row.times);
+    }
+  }
+  for(const key of Object.keys(result)){
+    result[key]=uniqueTimes(result[key].sort((a,b)=>a-b));
+  }
+  return result;
+}
+
 function openModal(r){
   const modal = document.getElementById('modal');
   modal.style.display='flex';
-  const topGaps = [...r.hw].sort((a,b)=>b-a).slice(0,10);
-  const departures = r.times.slice(0,20).map(m2t).join(', ');
-  document.getElementById('modalTitle').textContent = `Details — Route ${r.route} (${r.day}${r.dir==='—'?'':', dir '+r.dir})`;
+  const dirLabel = directionLabel(r.dir);
+  const dirText = dirLabel && dirLabel!=='–' ? `, ${dirLabel}` : '';
+  document.getElementById('modalTitle').textContent = `Details — Route ${r.route} (${r.day}${dirText})`;
+
+  const median = computeMedian(r.hw);
+  const mode = computeMode(r.hw);
+  const avg = r.hw.length ? Math.round(r.hw.reduce((a,b)=>a+b,0)/r.hw.length) : r.avg;
+  const gapGroups = formatGroupedGaps(r.hw);
+  const bucketOrder=['≤10','11–15','16–20','21–30','31–60','>60'];
+
+  const merge = document.getElementById('merge').checked;
+  let departuresHtml='';
+  if(merge){
+    const dedup=uniqueTimes(r.times);
+    const sample=dedup.slice(0,20).map(m2t).join(', ');
+    const more=dedup.length>20 ? ' …' : '';
+    departuresHtml=`<div><h4>All directions</h4><p>${sample||'—'}${more}</p></div>`;
+  }else{
+    const timesDir=timesByDirection(r.route,r.day);
+    const outbound=timesDir['0']||[];
+    const inbound=timesDir['1']||[];
+    const outboundSample=outbound.slice(0,20).map(m2t).join(', ');
+    const inboundSample=inbound.slice(0,20).map(m2t).join(', ');
+    const outboundMore=outbound.length>20?' …':'';
+    const inboundMore=inbound.length>20?' …':'';
+    departuresHtml=`
+      <div><h4>Outbound</h4><p>${outboundSample||'—'}${outboundMore}</p></div>
+      <div><h4>Inbound</h4><p>${inboundSample||'—'}${inboundMore}</p></div>
+    `;
+  }
+
+  const gapHtml = gapGroups.length ? gapGroups.map(g=>`<span class="chip">${g}</span>`).join(' ') : '<span class="muted">Not enough data</span>';
+
+  const bucketHtml = bucketOrder.map(label=>`<tr><td>${label}</td><td>${r.b[label]}</td></tr>`).join('');
+
   document.getElementById('modalBody').innerHTML = `
-    <p><strong>Least‑Worst Tier:</strong> ${r.tier==='>60'?'&gt;60':r.tier} min, <strong>Avg:</strong> ${r.avg} min</p>
-    <p><strong>Top 10 largest gaps (min):</strong> ${topGaps.join(', ')}</p>
-    <p class="muted">Sample origin departures (hh:mm): ${departures}${r.times.length>20?' …':''}</p>
-    <pre>${JSON.stringify(r.b,null,2)}</pre>
+    <div class="metrics">
+      <div class="metricCard">
+        <span class="metricLabel">Median headway</span>
+        <span class="metricValue">${formatMinutes(median)}</span>
+      </div>
+      <div class="metricCard">
+        <span class="metricLabel">Most common headway</span>
+        <span class="metricValue">${formatMinutes(mode)}</span>
+      </div>
+      <div class="metricCard">
+        <span class="metricLabel">Average headway</span>
+        <span class="metricValue">${formatMinutes(avg)}</span>
+        <div class="metricSub">Based on origin departures</div>
+      </div>
+    </div>
+    <div>
+      <p><strong>Top gaps:</strong></p>
+      <div class="gapList">${gapHtml}</div>
+    </div>
+    <div class="departures">${departuresHtml}</div>
+    <table class="modalBuckets">
+      <thead><tr><th>Bucket</th><th>Count</th></tr></thead>
+      <tbody>${bucketHtml}</tbody>
+    </table>
   `;
 }
 function closeModal(){ document.getElementById('modal').style.display='none'; }


### PR DESCRIPTION
## Summary
- add a persistent light/dark theme toggle, align the control row, and surface a frequent weekday banner with quick navigation
- update kanban cards, the table, and modal titles to show “Outbound/Inbound” or a dash when directions are merged, while keeping the strict tier tooltips and zebra styling
- expand the modal with median/mode headway stats, grouped gap chips, deduplicated departure samples, and a bucket summary table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf2e8d8c648322b2300ed8e04e9722